### PR TITLE
Display comment counts everywhere

### DIFF
--- a/ui/static/js/category.js
+++ b/ui/static/js/category.js
@@ -114,6 +114,15 @@ function renderCategoryPosts(category) {
     postNode.querySelector('.like-count').textContent = post.likes || 0;
     postNode.querySelector('.dislike-count').textContent = post.dislikes || 0;
 
+    const commentCount =
+      post.comment_count || (post.comments ? post.comments.length : 0);
+    const commentContainer = document.createElement('span');
+    commentContainer.className = 'comment-count';
+    commentContainer.innerHTML = `💬 ${commentCount}`;
+    postNode
+      .querySelector('.like-count')
+      .parentNode.appendChild(commentContainer);
+
     // Wrap post in clickable anchor, applying the 'post-link' class
     const postWrapper = document.createElement('a');
     postWrapper.href = `/guest/post?id=${encodeURIComponent(post.id)}`;

--- a/ui/static/js/guest/guest_post.js
+++ b/ui/static/js/guest/guest_post.js
@@ -62,6 +62,13 @@ function renderSinglePost(post) {
     <button disabled>▼ ${dislikes}</button>
   `;
 
+  const commentCount =
+    post.comment_count || (post.comments ? post.comments.length : 0);
+  const commentCounter = document.createElement('span');
+  commentCounter.className = 'comment-count';
+  commentCounter.textContent = `💬 ${commentCount}`;
+  reactions.appendChild(commentCounter);
+
   const categoryEl = document.createElement('div');
   categoryEl.className = 'post-categories';
   categoryEl.innerHTML = `<span class="posted-on-text">posted on the </span>`;

--- a/ui/static/js/user/user_category.js
+++ b/ui/static/js/user/user_category.js
@@ -122,6 +122,15 @@ function renderCategoryPosts(category, feedCategories) {
     postNode.querySelector('.like-count').textContent = likes;
     postNode.querySelector('.dislike-count').textContent = dislikes;
 
+    const commentCount =
+      post.comment_count || (post.comments ? post.comments.length : 0);
+    const commentContainer = document.createElement('span');
+    commentContainer.className = 'comment-count';
+    commentContainer.innerHTML = `💬 ${commentCount}`;
+    postNode
+      .querySelector('.like-count')
+      .parentNode.appendChild(commentContainer);
+
     const postWrapper = document.createElement('a');
     postWrapper.href = `/user/post?id=${encodeURIComponent(post.id)}`;
     postWrapper.className = 'post-link';

--- a/ui/static/js/user/user_created_posts.js
+++ b/ui/static/js/user/user_created_posts.js
@@ -46,6 +46,15 @@ function renderCreatedPosts(posts) {
     node.querySelector('.like-count').textContent = likeCount;
     node.querySelector('.dislike-count').textContent = dislikeCount;
 
+    const commentCount =
+      post.comment_count || (post.comments ? post.comments.length : 0);
+    const commentContainer = document.createElement('span');
+    commentContainer.className = 'comment-count';
+    commentContainer.innerHTML = `💬 ${commentCount}`;
+    node
+      .querySelector('.like-count')
+      .parentNode.appendChild(commentContainer);
+
     const wrapper = document.createElement('a');
     wrapper.href = `/user/post?id=${post.id}`;
     wrapper.className = 'post-link';

--- a/ui/static/js/user/user_liked_posts.js
+++ b/ui/static/js/user/user_liked_posts.js
@@ -57,6 +57,15 @@ function renderLikedPosts(posts) {
     node.querySelector('.like-count').textContent = likeCount;
     node.querySelector('.dislike-count').textContent = dislikeCount;
 
+    const commentCount =
+      post.comment_count || (post.comments ? post.comments.length : 0);
+    const commentContainer = document.createElement('span');
+    commentContainer.className = 'comment-count';
+    commentContainer.innerHTML = `💬 ${commentCount}`;
+    node
+      .querySelector('.like-count')
+      .parentNode.appendChild(commentContainer);
+
     // Wrap post in clickable link
     const wrapper = document.createElement('a');
     wrapper.href = `/user/post?id=${post.id}`;

--- a/ui/static/js/user/user_post.js
+++ b/ui/static/js/user/user_post.js
@@ -104,6 +104,13 @@ function renderSinglePost(post) {
   reactions.appendChild(likeBtn);
   reactions.appendChild(dislikeBtn);
 
+  const commentCount =
+    post.comment_count || (post.comments ? post.comments.length : 0);
+  const commentCounter = document.createElement('span');
+  commentCounter.className = 'comment-count';
+  commentCounter.textContent = `💬 ${commentCount}`;
+  reactions.appendChild(commentCounter);
+
   // Reaction button click handlers
   likeBtn.addEventListener('click', () => handleReaction(post.id, 'post', 1, likeBtn, dislikeBtn));
   dislikeBtn.addEventListener('click', () => handleReaction(post.id, 'post', 2, likeBtn, dislikeBtn));


### PR DESCRIPTION
## Summary
- show how many comments each post has on category pages
- add comment counts on lists of created or liked posts
- display comment count on single post views for both user and guest

## Testing
- `go fmt ./...` *(fails: directory prefix does not contain module)*

------
https://chatgpt.com/codex/tasks/task_e_68764a3bf1408324ac217008d97a915b