### PR TITLE
Fix post edit/delete and restyle buttons

### DIFF
--- a/ui/static/css/user_created_posts.css
+++ b/ui/static/css/user_created_posts.css
@@ -189,3 +189,37 @@ body, html {
   display: block;
   margin-bottom: 0.5em;
 }
+
+/* Action buttons inside each post */
+.post-actions {
+  margin-top: 0.5em;
+  display: flex;
+  gap: 0.8em;
+}
+
+.post-actions button {
+  padding: 0.6em 1.2em;
+  background: var(--gradient-main);
+  color: var(--color-primary);
+  border: none;
+  border-radius: 8px;
+  font-weight: bold;
+  cursor: pointer;
+  box-shadow: 0 3px 12px rgba(139, 92, 246, 0.4);
+  transition: all 0.3s ease-in-out;
+}
+
+.post-actions button:hover {
+  background: var(--gradient-accent);
+  transform: translateY(-2px);
+  box-shadow: 0 6px 20px rgba(139, 92, 246, 0.5);
+}
+
+.post-actions .delete-post {
+  background: linear-gradient(135deg, var(--color-warning), #42065e55);
+}
+
+.post-actions .delete-post:hover {
+  background: linear-gradient(135deg, #28033955, var(--color-warning));
+  box-shadow: 0 6px 20px rgba(60, 2, 118, 0.4);
+}

--- a/ui/static/js/user/user_created_posts.js
+++ b/ui/static/js/user/user_created_posts.js
@@ -1,7 +1,28 @@
 const forumContainer = document.getElementById('forumContainer');
 const postTemplate = document.getElementById('post-template');
 
-window.addEventListener('DOMContentLoaded', () => {
+// Endpoint used to verify the session and fetch the CSRF token
+const sessionVerifyURL = 'http://localhost:8080/forum/api/session/verify';
+
+// In-memory storage for the CSRF token
+let csrfTokenFromResponse = null;
+
+// Helper to load a fresh CSRF token from the backend
+async function loadCSRFTokenFromSession() {
+  try {
+    const resp = await fetch(sessionVerifyURL, { credentials: 'include' });
+    if (!resp.ok) throw new Error('Session not valid');
+    const data = await resp.json();
+    return data.csrf_token || data.CSRFToken;
+  } catch (err) {
+    console.warn('Failed to load CSRF token:', err);
+    return null;
+  }
+}
+
+window.addEventListener('DOMContentLoaded', async () => {
+  // Load CSRF token when the page is loaded
+  csrfTokenFromResponse = await loadCSRFTokenFromSession();
   fetchCreatedPosts();
 });
 
@@ -70,8 +91,19 @@ function renderCreatedPosts(posts) {
 
     const editBtn = wrapper.querySelector('.edit-post');
     const deleteBtn = wrapper.querySelector('.delete-post');
+
     editBtn.addEventListener('click', async e => {
       e.preventDefault();
+
+      // Ensure we have a CSRF token before making the request
+      if (!csrfTokenFromResponse) {
+        csrfTokenFromResponse = await loadCSRFTokenFromSession();
+        if (!csrfTokenFromResponse) {
+          alert('Session expired. Please log in again.');
+          return;
+        }
+      }
+
       const title = prompt('Edit title', post.title);
       if (title === null) return;
       const content = prompt('Edit content', post.content);
@@ -86,7 +118,10 @@ function renderCreatedPosts(posts) {
         const resp = await fetch('http://localhost:8080/forum/api/posts/update', {
           method: 'POST',
           credentials: 'include',
-          headers: { 'Content-Type': 'application/json' },
+          headers: {
+            'Content-Type': 'application/json',
+            'X-CSRF-Token': csrfTokenFromResponse,
+          },
           body: JSON.stringify(body),
         });
         if (!resp.ok) throw new Error('failed');
@@ -95,14 +130,28 @@ function renderCreatedPosts(posts) {
         alert('Failed to update post');
       }
     });
+
     deleteBtn.addEventListener('click', async e => {
       e.preventDefault();
       if (!confirm('Delete this post?')) return;
+
+      // Ensure CSRF token
+      if (!csrfTokenFromResponse) {
+        csrfTokenFromResponse = await loadCSRFTokenFromSession();
+        if (!csrfTokenFromResponse) {
+          alert('Session expired. Please log in again.');
+          return;
+        }
+      }
+
       try {
         const resp = await fetch('http://localhost:8080/forum/api/posts/delete', {
           method: 'POST',
           credentials: 'include',
-          headers: { 'Content-Type': 'application/json' },
+          headers: {
+            'Content-Type': 'application/json',
+            'X-CSRF-Token': csrfTokenFromResponse,
+          },
           body: JSON.stringify({ post_id: post.id }),
         });
         if (!resp.ok) throw new Error('failed');


### PR DESCRIPTION
## Summary
- reload CSRF token when viewing created posts
- send CSRF token on edit and delete requests
- style edit/delete buttons like other buttons on the site

## Testing
- `go vet ./...`

------
https://chatgpt.com/codex/tasks/task_e_687a0b996a948324a324cf5fbc175f76